### PR TITLE
Fix Issue of not finding cp command

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,9 +11,13 @@ let package = Package(
     ],
     dependencies: [],
     targets: [
+        .executableTarget(
+            name: "CopyLicensesFile"
+        ),
         .plugin(
             name: "LicensesPlugin",
-            capability: .buildTool()
+            capability: .buildTool(),
+            dependencies: ["CopyLicensesFile"]
         ),
     ]
 )

--- a/PluginDemos/CLIDemo/.gitignore
+++ b/PluginDemos/CLIDemo/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/PluginDemos/CLIDemo/Package.swift
+++ b/PluginDemos/CLIDemo/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 5.8
+
+import PackageDescription
+
+let package = Package(
+    name: "CLIDemo",
+    dependencies: [
+        // LicensesPlugin
+        .package(path: "../.."),
+    ],
+    targets: [
+        .executableTarget(
+            name: "CLIDemo",
+            path: "Sources",
+            plugins: [.plugin(name: "LicensesPlugin", package: "LicensesPlugin")]
+        ),
+    ]
+)

--- a/PluginDemos/CLIDemo/Sources/main.swift
+++ b/PluginDemos/CLIDemo/Sources/main.swift
@@ -1,0 +1,5 @@
+print("Licenses")
+
+LicensesPlugin.licenses.forEach { license in
+    print("- \(license.name)")
+}

--- a/PluginDemos/PluginDemos.xcworkspace/contents.xcworkspacedata
+++ b/PluginDemos/PluginDemos.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:CLIDemo">
+   </FileRef>
+   <FileRef
       location = "group:UIKitDemo/UIKitDemo.xcodeproj">
    </FileRef>
    <FileRef

--- a/Plugins/LicensesPlugin/LicensesPlugin.swift
+++ b/Plugins/LicensesPlugin/LicensesPlugin.swift
@@ -41,26 +41,28 @@ import PackagePlugin
         }
         """
         
-        let tmpOutputFilePathString = try tmpOutputFilePath().string
+        let tmpOutputFilePathString = try tmpOutputFilePath(packageID: context.package.id).string
         try generatedFileContent.write(to: URL(fileURLWithPath: tmpOutputFilePathString), atomically: true, encoding: .utf8)
         
         let outputFilePath = try outputFilePath(workDirectory: context.pluginWorkDirectory)
         
         return [
-            .prebuildCommand(
+            .buildCommand(
                 displayName: "LicensesPlugin",
-                executable: try context.tool(named: "cp").path,
+                executable: try context.tool(named: "CopyLicensesFile").path,
                 arguments: [tmpOutputFilePathString, outputFilePath.string],
-                outputFilesDirectory: outputFilePath.removingLastComponent()
+                inputFiles: [Path(tmpOutputFilePathString)],
+                outputFiles: [Path(outputFilePath.string)]
             )
         ]
     }
     
-    private let generatedFileName = "Licenses+Generated.swift"
     
-    private func tmpOutputFilePath() throws -> Path {
+    private func tmpOutputFilePath(packageID: String) throws -> Path {
         let tmpDirectory = Path(NSTemporaryDirectory())
         try FileManager.default.createDirectoryIfNotExists(atPath: tmpDirectory.string)
+        
+        let generatedFileName = "\(packageID)_Licenses+Generated.swift"
         return tmpDirectory.appending(generatedFileName)
     }
     

--- a/Sources/CopyLicensesFile/CopyLicensesFile.swift
+++ b/Sources/CopyLicensesFile/CopyLicensesFile.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+@main
+enum CopyLicensesFile {
+    private static let fileManager = FileManager.default
+    
+    static func main() throws {
+        guard CommandLine.arguments.count == 3 else {
+            print("This executable should be called with 2 arguments: CopyLicensesFile <source path> <destination path>")
+            exit(1)
+        }
+        let sourcePath = CommandLine.arguments[1]
+        let destinationPath = CommandLine.arguments[2]
+        
+        do {
+            if fileManager.fileExists(atPath: destinationPath) {
+                try fileManager.removeItem(atPath: destinationPath)
+            }
+            try fileManager.copyItem(atPath: sourcePath, toPath: destinationPath)
+        } catch {
+            print("Failed to copy licenses file: \(error)")
+            exit(1)
+        }
+    }
+}


### PR DESCRIPTION
Fix #17 

I couldn't identify the exact cause of this issue (may be related to https://forums.swift.org/t/plugin-doesnt-have-access-to-binary-package-manager-extensible-build-tools-se-0303-and-se-0305/56038/7 ?). But using system command `cp` directory seems unreliable.

This PR introduce the executable package to copy file to fix the issue.
