### PR TITLE
[Swift6] Retroactive conformances issue

### DIFF
--- a/Plugins/LicensesPlugin/LicensesPlugin.swift
+++ b/Plugins/LicensesPlugin/LicensesPlugin.swift
@@ -4,7 +4,7 @@ import PackagePlugin
 @main struct Plugin: BuildToolPlugin {
     func createBuildCommands(context: PackagePlugin.PluginContext, target: PackagePlugin.Target) async throws -> [PackagePlugin.Command] {
         let dependencies = context.package.getDependenciesRecursively()
-        let sortedDependencies = Array(dependencies).sorted(by: { $0.displayName.lowercased() < $1.displayName.lowercased() })
+        let sortedDependencies = dependencies.sorted(by: { $0.displayName.lowercased() < $1.displayName.lowercased() })
         let generatedLicensesText = sortedDependencies.map {
             if let licenseText = $0.readLicenseText() {
                 return """

--- a/Plugins/LicensesPlugin/Package+Extension.swift
+++ b/Plugins/LicensesPlugin/Package+Extension.swift
@@ -28,7 +28,7 @@ extension Package {
 
 extension [Package] {
     func uniqued() -> [Package] {
-        var new = self
+        var new: [Package] = []
         for element in self {
             if !new.contains(where: { $0.id == element.id }) {
                 new.append(element)

--- a/Plugins/LicensesPlugin/Package+Extension.swift
+++ b/Plugins/LicensesPlugin/Package+Extension.swift
@@ -1,22 +1,12 @@
 import Foundation
 import PackagePlugin
 
-extension Package: Hashable {
-    public static func == (lhs: PackagePlugin.Package, rhs: PackagePlugin.Package) -> Bool {
-        lhs.id == rhs.id
-    }
-    
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-    }
-}
-
 extension Package {
-    func getDependenciesRecursively() -> Set<Package> {
-        var allDependencies: Set<Package> = .init()
+    func getDependenciesRecursively() -> [Package] {
+        var allDependencies: [Package] = []
         for dependency in dependencies {
-            allDependencies.insert(dependency.package)
-            allDependencies.formUnion(dependency.package.getDependenciesRecursively())
+            allDependencies.append(dependency.package)
+            allDependencies.append(contentsOf: dependency.package.getDependenciesRecursively())
         }
         return allDependencies
     }
@@ -33,5 +23,17 @@ extension Package {
             }
         }
         return nil
+    }
+}
+
+extension [Package] {
+    func uniqued() -> [Package] {
+        var new = self
+        for element in self {
+            if !new.contains(where: { $0.id == element.id }) {
+                new.append(element)
+            }
+        }
+        return new
     }
 }

--- a/Plugins/LicensesPlugin/Package+Extension.swift
+++ b/Plugins/LicensesPlugin/Package+Extension.swift
@@ -8,7 +8,7 @@ extension Package {
             allDependencies.append(dependency.package)
             allDependencies.append(contentsOf: dependency.package.getDependenciesRecursively())
         }
-        return allDependencies
+        return allDependencies.uniqued()
     }
     
     func readLicenseText() -> String? {


### PR DESCRIPTION
In Swift6, It makes warning when conform protocol to types of another framework.
https://github.com/swiftlang/swift-evolution/blob/main/proposals/0364-retroactive-conformance-warning.md#L133

It can ignore by using @retroactive. But acutely we should't conform `Hashable `.
So, This PR is make `uniqued()` instead of `Set`. `uniqued()` isn't required `Hashable` conformance.

<img width="830" alt="スクリーンショット 2024-06-12 1 46 05" src="https://github.com/maiyama18/LicensesPlugin/assets/2066707/4ff87d1d-1ac7-4f0a-837b-32a2f3b412fe">
