### PR TITLE
Do not update dependencies for testing

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "ignorePaths": [
+    "PluginDemos/SwiftUIDemo/SwiftUIDemo/Packages/SwiftUIDemoPackage/Package.swift",
+    "PluginDemos/UIKitDemo/UIKitDemo/Packages/UIKitDemoPackage/Package.swift",
+    "PluginTests/ExamplePackage/Package.swift"
   ]
 }


### PR DESCRIPTION
We will configure Renovate to ignore the Swift libraries used for testing and demonstrations since they do not need to be updated.